### PR TITLE
feat: remove document field from supergraph, subgraph and query_planner

### DIFF
--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -399,12 +399,6 @@ impl Plugin for Telemetry {
         let name = name.to_owned();
         ServiceBuilder::new()
             .instrument(move |req: &SubgraphRequest| {
-                let query = req
-                    .subgraph_request
-                    .body()
-                    .query
-                    .clone()
-                    .unwrap_or_default();
                 let operation_name = req
                     .subgraph_request
                     .body()
@@ -415,7 +409,6 @@ impl Plugin for Telemetry {
                 info_span!(
                     SUBGRAPH_SPAN_NAME,
                     "apollo.subgraph.name" = name.as_str(),
-                    graphql.document = query.as_str(),
                     graphql.operation.name = operation_name.as_str(),
                     "otel.kind" = "INTERNAL",
                     "apollo_private.ftv1" = field::Empty
@@ -642,7 +635,6 @@ impl Telemetry {
     ) -> impl Fn(&SupergraphRequest) -> Span + Clone {
         move |request: &SupergraphRequest| {
             let http_request = &request.supergraph_request;
-            let query = http_request.body().query.clone().unwrap_or_default();
             let operation_name = http_request
                 .body()
                 .operation_name
@@ -651,7 +643,6 @@ impl Telemetry {
 
             let span = info_span!(
                 SUPERGRAPH_SPAN_NAME,
-                graphql.document = query.as_str(),
                 // TODO add graphql.operation.type
                 graphql.operation.name = operation_name.as_str(),
                 otel.kind = "INTERNAL",

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -254,11 +254,6 @@ async fn plan_query(
         )
         .instrument(tracing::info_span!(
             QUERY_PLANNING_SPAN_NAME,
-            graphql.document = body
-                .query
-                .clone()
-                .expect("the query presence was already checked by a plugin")
-                .as_str(),
             graphql.operation.name = body.operation_name.clone().unwrap_or_default().as_str(),
             "otel.kind" = "INTERNAL"
         ))
@@ -702,13 +697,13 @@ mod tests {
         {
           query: Query
         }
-        
+
         directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
         directive @join__graph(name: String!, url: String!) on ENUM_VALUE
         directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
         directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
         directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
-                
+
         scalar link__Import
         enum link__Purpose {
           SECURITY
@@ -722,9 +717,9 @@ mod tests {
           errorField: String
           nonNullErrorField: String!
         }
-        
+
         scalar join__FieldSet
-        
+
         enum join__Graph {
           COMPUTERS @join__graph(name: "computers", url: "http://localhost:4001/")
         }
@@ -779,8 +774,8 @@ mod tests {
         let request = supergraph::Request::fake_builder()
             .context(defer_context())
             .query(
-                r#"query { 
-                computer(id: "Computer1") {   
+                r#"query {
+                computer(id: "Computer1") {
                   id
                   ...ComputerErrorField @defer
                 }
@@ -1184,55 +1179,55 @@ mod tests {
     query: Query
     mutation: Mutation
   }
-  
+
   directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-  
+
   directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
-  
+
   directive @join__graph(name: String!, url: String!) on ENUM_VALUE
-  
+
   directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
-  
+
   directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
-  
+
   directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
-  
+
   directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-  
+
   scalar join__FieldSet
-  
+
   enum join__Graph {
     PRODUCTS @join__graph(name: "products", url: "http://products:4000/graphql")
     USERS @join__graph(name: "users", url: "http://users:4000/graphql")
   }
-  
+
   scalar link__Import
-  
+
   enum link__Purpose {
     SECURITY
     EXECUTION
   }
-  
+
   type MakePaymentResult
     @join__type(graph: USERS)
   {
     id: ID!
     paymentStatus: PaymentStatus
   }
-  
+
   type Mutation
     @join__type(graph: USERS)
   {
     makePayment(userId: ID!): MakePaymentResult!
   }
-  
-  
+
+
  type PaymentStatus
     @join__type(graph: USERS)
   {
     id: ID!
   }
-  
+
   type Query
     @join__type(graph: PRODUCTS)
     @join__type(graph: USERS)
@@ -1410,7 +1405,7 @@ mod tests {
             {
                 query: Query
             }
-        
+
             directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
             directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
             directive @join__graph(name: String!, url: String!) on ENUM_VALUE
@@ -1418,7 +1413,7 @@ mod tests {
             directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
             directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
             directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-        
+
             scalar join__FieldSet
             enum join__Graph {
                 USER @join__graph(name: "user", url: "http://localhost:4000/graphql")
@@ -1439,7 +1434,7 @@ mod tests {
             id: ID!
             name: String!
             }
-        
+
             type User implements Identity
                 @join__implements(graph: USER, interface: "Identity")
                 @join__type(graph: USER, key: "id")
@@ -2265,7 +2260,7 @@ mod tests {
           {
             foo: Foo! @join__field(graph: S1)
           }
-          
+
           type Foo
             @join__owner(graph: S1)
             @join__type(graph: S1)
@@ -2273,7 +2268,7 @@ mod tests {
             id: ID! @join__field(graph: S1)
             bar: Bar! @join__field(graph: S1)
           }
-          
+
           type Bar
           @join__owner(graph: S1)
           @join__type(graph: S1, key: "id")


### PR DESCRIPTION
remove `graphql.document` fields from `supergraph`, `subgraph` and `query_planning` spans, those are cloned causing an increase on memory usage and could potentially cause a bottleneck in otel datadog exporter to dd agent / dd agent to dd api

