### PR TITLE
feat: add operation name along with PersistedQueryNotFound error events.

### DIFF
--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -170,6 +170,7 @@ async fn apq_request(
                     path: Default::default(),
                     extensions: serde_json_bytes::from_value(json!({
                       "code": "PERSISTED_QUERY_NOT_FOUND",
+                      "operationName": request.supergraph_request.body_mut().operation_name.clone().unwrap_or("NO OPERATION NAME PROVIDED".to_string()),
                     }))
                     .unwrap(),
                 }];
@@ -269,6 +270,7 @@ mod apq_tests {
             path: Default::default(),
             extensions: serde_json_bytes::from_value(json!({
               "code": "PERSISTED_QUERY_NOT_FOUND",
+              "operationName": "testOperation",
             }))
             .unwrap(),
         };
@@ -305,6 +307,7 @@ mod apq_tests {
 
         let hash_only = SupergraphRequest::fake_builder()
             .extension("persistedQuery", persisted.clone())
+            .operation_name("testOperation".to_string())
             .context(new_context())
             .build()
             .expect("expecting valid request")
@@ -395,6 +398,7 @@ mod apq_tests {
             path: Default::default(),
             extensions: serde_json_bytes::from_value(json!({
               "code": "PERSISTED_QUERY_NOT_FOUND",
+              "operationName": "NO OPERATION NAME PROVIDED",
             }))
             .unwrap(),
         };


### PR DESCRIPTION
*Description here*

When an Automatic Persisted Queries (APQ) request is made with an invalid hash, the router will return a PersistedQueryNotFound error.

This change enhances logging of these events by providing the operation name that was attempted with the request.
