### PR TITLE
feat: log operation name for PersistedQueryNotFound events

### DIFF
--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -164,6 +164,13 @@ async fn apq_request(
             } else {
                 let _ = request.context.insert(PERSISTED_QUERY_CACHE_HIT, false);
                 tracing::trace!("apq: cache miss");
+
+                let operation_name = request.supergraph_request.body().operation_name
+                    .clone()
+                    .unwrap_or_else(|| "NO OPERATION NAME PROVIDED".to_string());
+                
+                tracing::info!(message = "PersistedQueryNotFound", operation = format!("{}", operation_name));
+                
                 let errors = vec![crate::error::Error {
                     message: "PersistedQueryNotFound".to_string(),
                     locations: Default::default(),

--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -169,7 +169,7 @@ async fn apq_request(
                     .clone()
                     .unwrap_or_else(|| "NO OPERATION NAME PROVIDED".to_string());
                 
-                tracing::info!(message = "PersistedQueryNotFound", operation = format!("{}", operation_name));
+                tracing::info!(message = "PersistedQueryNotFound", operation = operation_name);
                 
                 let errors = vec![crate::error::Error {
                     message: "PersistedQueryNotFound".to_string(),


### PR DESCRIPTION
*Description here*

When an Automatic Persisted Queries (APQ) request is made with an invalid hash, the router will return a PersistedQueryNotFound event.

This change enhances logging of these events by logging the operation name that was attempted with the request.