### PR TITLE
feat: pub telemetry

### DIFF
--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -68,7 +68,7 @@ mod introspection;
 pub mod layers;
 pub(crate) mod logging;
 mod orbiter;
-mod plugins;
+pub mod plugins;
 pub(crate) mod protocols;
 mod query_planner;
 mod router;

--- a/apollo-router/src/plugins/mod.rs
+++ b/apollo-router/src/plugins/mod.rs
@@ -44,7 +44,7 @@ mod record_replay;
 pub(crate) mod response_cache;
 pub(crate) mod rhai;
 pub(crate) mod subscription;
-pub(crate) mod telemetry;
+pub mod telemetry;
 #[cfg(test)]
 pub(crate) mod test;
 pub(crate) mod traffic_shaping;

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -158,11 +158,11 @@ pub(crate) mod formatters;
 mod logging;
 pub(crate) mod metrics;
 /// Opentelemetry utils
-pub(crate) mod otel;
+pub mod otel;
 mod otlp;
 pub(crate) mod reload;
 pub(crate) mod resource;
-pub(crate) mod span_ext;
+pub mod span_ext;
 mod span_factory;
 pub(crate) mod tracing;
 pub(crate) mod utils;

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -160,7 +160,7 @@ pub(crate) mod metrics;
 /// Opentelemetry utils
 pub mod otel;
 mod otlp;
-pub(crate) mod reload;
+pub mod reload;
 pub(crate) mod resource;
 pub mod span_ext;
 mod span_factory;

--- a/apollo-router/src/plugins/telemetry/otel/mod.rs
+++ b/apollo-router/src/plugins/telemetry/otel/mod.rs
@@ -2,7 +2,7 @@
 pub(crate) mod layer;
 pub(crate) mod named_runtime_channel;
 /// Span extension which enables OpenTelemetry context management.
-pub(crate) mod span_ext;
+pub mod span_ext;
 /// Protocols for OpenTelemetry Tracers that are compatible with Tracing
 pub(crate) mod tracer;
 
@@ -10,7 +10,7 @@ pub(crate) use layer::OpenTelemetryLayer;
 pub(crate) use layer::layer;
 use opentelemetry::Key;
 use opentelemetry::Value;
-pub(crate) use span_ext::OpenTelemetrySpanExt;
+pub use span_ext::OpenTelemetrySpanExt;
 pub(crate) use tracer::PreSampledTracer;
 
 /// Per-span OpenTelemetry data tracked by this crate.

--- a/apollo-router/src/plugins/telemetry/otel/span_ext.rs
+++ b/apollo-router/src/plugins/telemetry/otel/span_ext.rs
@@ -9,7 +9,7 @@ use super::layer::WithContext;
 /// [`Span`]: tracing::Span
 /// [OpenTelemetry]: https://opentelemetry.io
 /// [`Context`]: opentelemetry::Context
-pub(crate) trait OpenTelemetrySpanExt {
+pub trait OpenTelemetrySpanExt {
     /// Associates `self` with a given OpenTelemetry trace, using the provided
     /// followed span [`SpanContext`].
     ///

--- a/apollo-router/src/plugins/telemetry/reload/mod.rs
+++ b/apollo-router/src/plugins/telemetry/reload/mod.rs
@@ -47,7 +47,7 @@ use crate::plugins::telemetry::reload::builder::Builder;
 pub(crate) mod activation;
 pub(crate) mod builder;
 pub(crate) mod metrics;
-pub(crate) mod otel;
+pub mod otel;
 pub(crate) mod tracing;
 
 /// Prepares telemetry components for activation (Phase 1 of reload lifecycle).

--- a/apollo-router/src/plugins/telemetry/reload/otel.rs
+++ b/apollo-router/src/plugins/telemetry/reload/otel.rs
@@ -137,7 +137,7 @@ pub(crate) fn apollo_opentelemetry_initialized() -> bool {
 // In that case we still need to propagate headers to subgraphs to tell them they should not sample the trace.
 // To that end, we update the context just for that request to create valid span et trace ids, with the
 // sampling bit set to false
-pub(crate) fn prepare_context(context: Context) -> Context {
+pub fn prepare_context(context: Context) -> Context {
     if !context.span().span_context().is_valid()
         && let Some(tracer) = OPENTELEMETRY_TRACER_HANDLE.get()
     {

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -98,6 +98,7 @@ async fn mock_subgraph_service_with_panics_should_be_reported_as_service_closed(
         query_metrics: Default::default(),
         usage_reporting: UsageReporting::Error("this is a test report key".to_string()).into(),
         estimated_size: Default::default(),
+        compute_duration: None
     };
 
     let mut mock_products_service = plugin::test::MockSubgraphService::new();
@@ -154,6 +155,7 @@ async fn fetch_includes_operation_name() {
         query: Arc::new(Query::empty_for_tests()),
         query_metrics: Default::default(),
         estimated_size: Default::default(),
+        compute_duration: None
     };
 
     let succeeded: Arc<AtomicBool> = Default::default();
@@ -219,6 +221,7 @@ async fn fetch_makes_post_requests() {
         query: Arc::new(Query::empty_for_tests()),
         query_metrics: Default::default(),
         estimated_size: Default::default(),
+        compute_duration: None,
     };
 
     let succeeded: Arc<AtomicBool> = Default::default();
@@ -353,6 +356,7 @@ async fn defer() {
             query: Arc::new(Query::empty_for_tests()),
             query_metrics: Default::default(),
             estimated_size: Default::default(),
+            compute_duration: None
         };
 
     let mut mock_x_service = plugin::test::MockSubgraphService::new();
@@ -490,6 +494,7 @@ async fn defer_if_condition() {
         formatted_query_plan: None,
         query_metrics: Default::default(),
         estimated_size: Default::default(),
+        compute_duration: None
     };
 
     let mocked_accounts = MockSubgraph::builder()
@@ -647,6 +652,7 @@ async fn dependent_mutations() {
         query: Arc::new(Query::empty_for_tests()),
         query_metrics: Default::default(),
         estimated_size: Default::default(),
+        compute_duration: None
     };
 
     let mut mock_a_service = plugin::test::MockSubgraphService::new();
@@ -1869,6 +1875,7 @@ fn broken_plan_does_not_panic() {
         query: Arc::new(Query::empty_for_tests()),
         query_metrics: Default::default(),
         estimated_size: Default::default(),
+        compute_duration: None
     };
     let subgraph_schema = apollo_compiler::Schema::parse_and_validate(subgraph_schema, "").unwrap();
     let mut subgraph_schemas = HashMap::default();


### PR DESCRIPTION
allow to use telemetry traits and functions to facilitate distributed tracing context propagation