### PR TITLE
fix: avoid cloning subgraph_request for every request

### DIFF
--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -177,7 +177,7 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, request: SubgraphRequest) -> Self::Future {
+    fn call(&mut self, mut request: SubgraphRequest) -> Self::Future {
         let service_name = (*self.service).to_owned();
 
         let client_factory = self.client_factory.clone();
@@ -188,13 +188,8 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
             // XXX(@goto-bus-stop): We are cloning the subgraph request potentially 3 times below.
             // It will normally not be super expensive? but it still does not seem great or
             // necessary.
-
-            let SubgraphRequest {
-                subgraph_request,
-                context,
-                ..
-            } = request.clone();
-            let body = subgraph_request.into_body();
+            let body = std::mem::take(request.subgraph_request.body_mut());
+            let context = request.context.clone();
 
             // If APQ is not enabled, simply make the graphql call
             // with the same request body.
@@ -213,27 +208,19 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
             // Else, if APQ is enabled,
             // Calculate the query hash and try the request with
             // a persistedQuery instead of the whole query.
-            let graphql::Request {
-                query,
-                operation_name,
-                variables,
-                extensions,
-            } = body.clone();
-
-            let hash_value = apq::calculate_hash_for_query(query.as_deref().unwrap_or_default());
-
+            let hash_value = apq::calculate_hash_for_query(body.query.as_deref().unwrap_or_default());
             let persisted_query = serde_json_bytes::json!({
                 HASH_VERSION_KEY: HASH_VERSION_VALUE,
                 HASH_KEY: hash_value
             });
 
-            let mut extensions_with_apq = extensions.clone();
+            let mut extensions_with_apq = body.extensions.clone();
             extensions_with_apq.insert(PERSISTED_QUERY_KEY, persisted_query);
 
             let mut apq_body = graphql::Request {
                 query: None,
-                operation_name,
-                variables,
+                operation_name: body.operation_name.clone(),
+                variables: body.variables.clone(),
                 extensions: extensions_with_apq,
             };
 
@@ -264,7 +251,7 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
                     .await
                 }
                 APQError::PersistedQueryNotFound => {
-                    apq_body.query = query;
+                    apq_body.query = body.query;
                     call_http(
                         request,
                         apq_body,
@@ -794,12 +781,14 @@ async fn call_http(
 
 /// call_single_http makes http calls with modified graphql::Request (body)
 pub(crate) async fn call_single_http(
-    request: SubgraphRequest,
-    body: graphql::Request,
+    mut request: SubgraphRequest,
+    mut body: graphql::Request,
     context: Context,
     client: crate::services::http::BoxService,
     service_name: &str,
 ) -> Result<SubgraphResponse, BoxError> {
+    // Swap the body back into the request so that telemetry see the body from request.
+    std::mem::swap(request.subgraph_request.body_mut(), &mut body);
     let subgraph_request_event = context
         .extensions()
         .with_lock(|lock| lock.get::<SubgraphEventRequest>().cloned());
@@ -810,6 +799,8 @@ pub(crate) async fn call_single_http(
             None
         }
     });
+    // Swap back
+    std::mem::swap(request.subgraph_request.body_mut(), &mut body);
 
     let SubgraphRequest {
         subgraph_request,
@@ -817,11 +808,11 @@ pub(crate) async fn call_single_http(
         ..
     } = request;
 
-    let operation_name = subgraph_request
-        .body()
+    let operation_name = body
         .operation_name
-        .clone()
-        .unwrap_or_default();
+        .as_deref()
+        .unwrap_or_default()
+        .to_owned();
 
     let (parts, _) = subgraph_request.into_parts();
     let body = serde_json::to_string(&body)?;

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -812,7 +812,7 @@ pub(crate) async fn call_single_http(
         .operation_name
         .as_deref()
         .unwrap_or_default()
-        .to_owned();
+        .clone();
 
     let (parts, _) = subgraph_request.into_parts();
     let body = serde_json::to_string(&body)?;

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -811,8 +811,7 @@ pub(crate) async fn call_single_http(
     let operation_name = body
         .operation_name
         .as_deref()
-        .unwrap_or_default()
-        .clone();
+        .unwrap_or_default();
 
     let (parts, _) = subgraph_request.into_parts();
     let body = serde_json::to_string(&body)?;


### PR DESCRIPTION
# Summary
[As explained by](https://github.com/apollographql/router/blob/dev/apollo-router/src/services/subgraph_service.rs#L191) @goto-bus-stop 
```
We are cloning the subgraph request potentially 3 times below.
It will normally not be super expensive? but it still does not seem great or
necessary.
```
it is expensive :P 

For every request that router sends to subgraphs [it clones the whole SubgraphRequest](https://github.com/apollographql/router/blob/dev/apollo-router/src/services/subgraph_service.rs#L199), then [it clones the graphql body](https://github.com/apollographql/router/blob/dev/apollo-router/src/services/subgraph_service.rs#L224) if APQ is enabled for the subgraph and finally clones the [SubgraphRequest and the apq_body again ](https://github.com/apollographql/router/blob/dev/apollo-router/src/services/subgraph_service.rs#L244).

This is specially bad for router that handing a large amount of traffic and/or big payloads to subgraphs, we are talking about possibly hundreds of megabytes being created and dropped per second.

# Proposed Changes
I wanted to draft something quick, with the minimal changes, avoid refactors
1. Replace clone-and-destructure of `SubgraphRequest` with `std::mem::take` to extract the body in-place, eliminating one full request clone on every subgraph call.
2. [APQ PATH] Read body fields directly instead of cloning the entire `graphql::Request` a second time for APQ hash 
3. [APQ_PATH]Move body.query instead of cloning it in the `PersistedQueryNotFound` retry
4. **NOT A FAN OF DOING THIS**: Temporarily swap the body back into the request before telemetry `evaluate_request` so selectors see correct values, then swap it out again.

**OVERALL savings** 
- On the no APQ path: eliminates one `SubgraphRequest` clone per subgraph fetch.                                                                               
- On the APQ path: eliminates one `SubgraphRequest` clone and one `graphql::Request` body clone

# Some numbers with help of AI

Assuming 550 TPS with an average query size of 50KB across 5 subgraphs.
### No APQ Path
|  | Before | After |
|---|--------|-------|
| Clones per request | 1 × SubgraphRequest (~50KB body + headers) | 0 |
| Per subgraph | 27.5 MB/s | 0 MB/s |
| × 5 subgraphs | **137.5 MB/s** | **0 MB/s** |
### APQ Path
|  | Before | After |
|---|--------|-------|
| Clones per request | 2 × SubgraphRequest + 1 × full body (~150KB) | 1 × SubgraphRequest + field-level clones (~55KB) |
| Per subgraph | 82.5 MB/s | 30.25 MB/s |
| × 5 subgraphs | **412.5 MB/s** | **151.25 MB/s** |

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] PR description explains the motivation for the change and relevant context for reviewing
- [ ] PR description links appropriate GitHub/Jira tickets (creating when necessary)
- [ ] Changeset is included for user-facing changes
- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- [ ] Metrics and logs are added[^3] and documented
- Tests added and passing[^4]
    - [ ] Unit tests
    - [ ] Integration tests
    - [ ] Manual tests, as necessary
