### PR TITLE
feat: expose query_planner module and key types publicly

### DIFF
--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -70,7 +70,7 @@ pub(crate) mod logging;
 mod orbiter;
 pub mod plugins;
 pub(crate) mod protocols;
-mod query_planner;
+pub mod query_planner;
 mod router;
 mod router_factory;
 pub mod services;

--- a/apollo-router/src/query_planner/convert.rs
+++ b/apollo-router/src/query_planner/convert.rs
@@ -6,7 +6,7 @@ use crate::query_planner::plan;
 use crate::query_planner::rewrites;
 use crate::query_planner::subscription;
 
-pub(crate) fn convert_root_query_plan_node(js: &next::QueryPlan) -> Option<plan::PlanNode> {
+pub fn convert_root_query_plan_node(js: &next::QueryPlan) -> Option<plan::PlanNode> {
     let next::QueryPlan {
         node,
         statistics: _,

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -11,11 +11,11 @@ pub(crate) use subgraph_context::build_operation_with_aliasing;
 pub use self::fetch::OperationKind;
 
 mod caching_query_planner;
-mod convert;
+pub mod convert;
 mod execution;
-pub(crate) mod fetch;
+pub mod fetch;
 mod labeler;
-mod plan;
+pub mod plan;
 pub(crate) mod query_planner_service;
 pub(crate) mod rewrites;
 pub(crate) mod selection;

--- a/apollo-router/src/query_planner/plan.rs
+++ b/apollo-router/src/query_planner/plan.rs
@@ -109,7 +109,7 @@ impl QueryPlan {
 /// Query plans are composed of a set of nodes.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "PascalCase", tag = "kind")]
-pub(crate) enum PlanNode {
+pub enum PlanNode {
     /// These nodes must be executed in order.
     Sequence {
         /// The plan nodes that make up the sequence execution.


### PR DESCRIPTION
Make the following items public so they can be accessed.

- `query_planner` module (lib.rs: mod → pub mod)
- `query_planner::plan` sub-module (mod.rs: mod → pub mod)
- `query_planner::convert` sub-module (mod.rs: mod → pub mod)
- `query_planner::fetch` sub-module (mod.rs: pub(crate) → pub)
- `PlanNode` enum (plan.rs: pub(crate) → pub)
- `convert_root_query_plan_node` fn (convert.rs: pub(crate) → pub)

<!-- start metadata -->

<!-- [ROUTER-####] -->
---

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: A lot of (if not most) features benefit from built-in observability and `debug`-level logs. Please read [this guidance](https://github.com/apollographql/router/blob/dev/dev-docs/metrics.md#adding-new-metrics) on metrics best-practices.
[^4]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
